### PR TITLE
ENV: auth URL을 환경변수로 변경

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,13 +4,20 @@ import { UsersService } from 'src/users/users.service';
 import { Response } from 'express';
 import { FtAuthGuard } from './ft-auth.guard';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { ConfigService } from '@nestjs/config';
 
 @Controller('auth')
 export class AuthController {
   constructor(
     private authService: AuthService,
     private userService: UsersService,
+    private readonly configService: ConfigService,
   ) {}
+
+  @Get('oauth')
+  async oauth(@Res({ passthrough: true }) res: Response) {
+    res.status(302).redirect(this.configService.get('auth.url'));
+  }
 
   @UseGuards(JwtAuthGuard)
   @Get()
@@ -37,8 +44,7 @@ export class AuthController {
       httpOnly: true,
       expires: new Date(Date.now() + 1000 * 60 * 60 * 24),
     });
-    res.status(302).redirect('.');
-    //res.status(302).redirect('http://localhost:80/auth');
+    res.status(302).redirect(this.configService.get('auth.callbackUrl'));
     return;
   }
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -18,4 +18,8 @@ export default () => ({
   jwt: {
     secret: process.env.JWT_SECRET,
   },
+  auth: {
+    url: process.env.AUTH_URL,
+    callbackUrl: process.env.CALLBACK_URL,
+  },
 });


### PR DESCRIPTION
.env에 추가해야할 변수들입니다.

AUTH_URL=https://api.intra.42.fr/oauth/authorize?client_id=c5e22b602708659fd8d3fbf6350271f01bbc47e58d342bc00859d7880b7bbe6e&redirect_uri=http%3A%2F%2Flocalhost%3A3001%2Fapi%2Fauth%2Ftoken&response_type=code
CALLBACK_URL=http://localhost:80/auth