### PR TITLE
UPDATE: add cookie option

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,7 +5,6 @@ import { Response } from 'express';
 import { FtAuthGuard } from './ft-auth.guard';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { ConfigService } from '@nestjs/config';
-import { NONAME } from 'dns';
 
 @Controller('auth')
 export class AuthController {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import { Response } from 'express';
 import { FtAuthGuard } from './ft-auth.guard';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { ConfigService } from '@nestjs/config';
+import { NONAME } from 'dns';
 
 @Controller('auth')
 export class AuthController {
@@ -43,6 +44,8 @@ export class AuthController {
 
       res.cookie('access_token', jwtToken, {
         httpOnly: true,
+        secure: true,
+        sameSite: 'none',
         expires: new Date(Date.now() + 1000 * 60 * 60 * 24),
       });
       return res


### PR DESCRIPTION
## issue
close #68 
## description
쿠키에 sameSite = 'none', secure=true 옵션을 추가하여 origin 이 localhost일 때 로그인 api가 서버에 쿠키를 전달하지 않는 문제를 해결하였습니다. secure=true 로 변경하면서 배포된 서버에 인증서를 달아주어 https 요청이 가능하게끔 하였습니다.