### PR TITLE
fix: lending create시, bookId 또는 userId가 null일 때 예외처리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1893,6 +1893,15 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/joi": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-17.2.3.tgz",
+      "integrity": "sha512-dGjs/lhrWOa+eO0HwgxCSnDm5eMGCsXuvLglMghJq32F6q5LyyNuXb41DHzrg501CKNOSSAHmfB7FDGeUnDmzw==",
+      "dev": true,
+      "requires": {
+        "joi": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "cookie-parser": "^1.4.5",
     "cross-env": "^7.0.3",
     "fastify-cookie": "^5.3.1",
-    "joi": "^17.4.2",
     "logger": "0.0.1",
     "mysql": "^2.18.1",
     "mysql2": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/express": "^4.17.13",
     "@types/faker": "^5.5.8",
     "@types/jest": "^26.0.24",
+    "@types/joi": "^17.2.3",
     "@types/node": "^16.0.0",
     "@types/passport-jwt": "^3.0.6",
     "@types/passport-local": "^1.0.34",

--- a/src/lendings/dto/create-lending.dto.ts
+++ b/src/lendings/dto/create-lending.dto.ts
@@ -1,5 +1,12 @@
+import { IsString, IsNumber } from 'class-validator';
+
 export class CreateLendingDto {
+  @IsString()
   condition: string;
+
+  @IsNumber()
   userId: number;
+
+  @IsNumber()
   bookId: number;
 }

--- a/src/lendings/entities/lending.entity.ts
+++ b/src/lendings/entities/lending.entity.ts
@@ -35,7 +35,7 @@ export class Lending {
   updatedAt: Date;
 
   @Expose({ groups: ['lendings.search', 'lendings.findOne'] })
-  @ManyToOne(() => User, (user) => user.lendings, {nullable:false})
+  @ManyToOne(() => User, (user) => user.lendings, { nullable: false })
   user: User;
 
   @ManyToOne(() => User, (librarian) => librarian.librarianLendings)
@@ -43,7 +43,7 @@ export class Lending {
   librarian: User;
 
   @Expose({ groups: ['lendings.search', 'lendings.findOne'] })
-  @ManyToOne(() => Book, (book) => book.lendings, {nullable:false})
+  @ManyToOne(() => Book, (book) => book.lendings, { nullable: false })
   book: Book;
 
   @OneToOne(() => Returning, (returning) => returning.lending)

--- a/src/lendings/entities/lending.entity.ts
+++ b/src/lendings/entities/lending.entity.ts
@@ -35,7 +35,7 @@ export class Lending {
   updatedAt: Date;
 
   @Expose({ groups: ['lendings.search', 'lendings.findOne'] })
-  @ManyToOne(() => User, (user) => user.lendings)
+  @ManyToOne(() => User, (user) => user.lendings, {nullable:false})
   user: User;
 
   @ManyToOne(() => User, (librarian) => librarian.librarianLendings)
@@ -43,7 +43,7 @@ export class Lending {
   librarian: User;
 
   @Expose({ groups: ['lendings.search', 'lendings.findOne'] })
-  @ManyToOne(() => Book, (book) => book.lendings)
+  @ManyToOne(() => Book, (book) => book.lendings, {nullable:false})
   book: Book;
 
   @OneToOne(() => Returning, (returning) => returning.lending)

--- a/src/lendings/lendings.controller.ts
+++ b/src/lendings/lendings.controller.ts
@@ -14,6 +14,7 @@ import {
   SerializeOptions,
   DefaultValuePipe,
   ParseIntPipe,
+  ValidationPipe,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { LendingsService } from './lendings.service';
@@ -28,7 +29,10 @@ export class LendingsController {
 
   @UseGuards(JwtAuthGuard)
   @Post()
-  async create(@Req() req, @Body() createLendingDtos: CreateLendingDto[]) {
+  async create(
+    @Req() req,
+    @Body(new ValidationPipe()) createLendingDtos: CreateLendingDto[],
+  ) {
     const librarianId = req.user.id;
     for (const dto of createLendingDtos)
       await this.lendingsService.create(dto, librarianId);

--- a/src/lendings/lendings.service.ts
+++ b/src/lendings/lendings.service.ts
@@ -83,6 +83,8 @@ export class LendingsService {
     const lendingData = await this.getLending(dto.bookId);
     if (lendingData != undefined && !lendingData.returning)
       throw new BadRequestException('대출된 책입니다.');
+    const findUser = await this.userService.findOne(dto.userId);
+    const { title } = await this.booksService.findOne(dto.bookId);
     try {
       await this.lendingsRepository.insert({
         condition: dto.condition,
@@ -90,8 +92,6 @@ export class LendingsService {
         librarian: { id: librarianId },
         book: { id: dto.bookId },
       });
-      const findUser = await this.userService.findOne(dto.userId);
-      const { title } = await this.booksService.findOne(dto.bookId);
       const now = new Date();
       const limitDay = new Date(
         now.setDate(now.getDate() + 14),

--- a/src/lendings/lendings.service.ts
+++ b/src/lendings/lendings.service.ts
@@ -83,8 +83,6 @@ export class LendingsService {
     const lendingData = await this.getLending(dto.bookId);
     if (lendingData != undefined && !lendingData.returning)
       throw new BadRequestException('대출된 책입니다.');
-    const findUser = await this.userService.findOne(dto.userId);
-    const { title } = await this.booksService.findOne(dto.bookId);
     try {
       await this.lendingsRepository.insert({
         condition: dto.condition,
@@ -92,6 +90,8 @@ export class LendingsService {
         librarian: { id: librarianId },
         book: { id: dto.bookId },
       });
+      const findUser = await this.userService.findOne(dto.userId);
+      const { title } = await this.booksService.findOne(dto.bookId);
       const now = new Date();
       const limitDay = new Date(
         now.setDate(now.getDate() + 14),


### PR DESCRIPTION
### issue
---
#53 

### description
---
lending create시, body 파라미터 중 userId 또는 bookId가 null일 때 db상에 null로 저장되는 문제 해결
-> throw not found